### PR TITLE
Remove object spread deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 module.exports = {
   'extends': 'airbnb-base',
   parserOptions: {
+    ecmaVersion: 2018,
     ecmaFeatures: {
-      experimentalObjectRestSpread: true,
       jsx: true
     }
   },

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'extends': 'airbnb-base',
+  extends: 'airbnb-base',
   parserOptions: {
     ecmaVersion: 2018,
     ecmaFeatures: {
@@ -26,4 +26,4 @@ module.exports = {
     }],
     'spaced-comment': 0
   }
-}
+};


### PR DESCRIPTION
The object spread option has been deprecated: https://eslint.org/docs/user-guide/migrating-to-5.0.0#experimental-object-rest-spread