### PR TITLE
Add no-only-tests rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 module.exports = {
-  'extends': 'airbnb-base',
+  extends: 'airbnb-base',
+  plugins: [
+    'no-only-tests'
+  ],
   parserOptions: {
     ecmaFeatures: {
       experimentalObjectRestSpread: true,
@@ -14,6 +17,7 @@ module.exports = {
     'max-len': [1, 100, { ignoreTrailingComments: true }],
     'new-cap': 1,
     'no-console': 1,
+    'no-only-tests/no-only-tests': 2,
     'no-param-reassign': 0,
     'no-return-assign': 1,
     'object-curly-newline': 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -549,6 +549,11 @@
         "jsx-ast-utils": "^2.2.1"
       }
     },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz",
+      "integrity": "sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ=="
+    },
     "eslint-plugin-react": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "eslint": "^4.9.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0"
   }


### PR DESCRIPTION
Adds rule to help prevent committing of `.only` in JS tests.