### PR TITLE
Turn off `no-plusplus` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
     'no-console': 'warn',
     'no-only-tests/no-only-tests': 'error',
     'no-param-reassign': 'off',
+    'no-plusplus': 'off',
     'no-return-assign': 'warn',
     'object-curly-newline': 'off',
     'prefer-destructuring': 'off',


### PR DESCRIPTION
The `no-plusplus` rule is only a concern if the code style/linting does not enforce semicolons. Our configs do not do this, therefore, this rule is not necessary (and, also, `++` is pretty handy).

More info: https://eslint.org/docs/rules/no-plusplus